### PR TITLE
Fix LHCODataset filter argument bug

### DIFF
--- a/data_model/dataset_bio.py
+++ b/data_model/dataset_bio.py
@@ -318,7 +318,7 @@ class LimbDataset(DigitsDataset):
 
 
 class LHCODataset(DigitsDataset):
-    def load_data(self, data_path, train=True):
+    def load_data(self, data_path, train=True, filter=True):
         adata = sc.read("/any/data/difftreedata/datasets_bio/processed/LHCO.h5ad")
         if filter:
             # sc.pp.subsample(adata, fraction=0.1)


### PR DESCRIPTION
## Summary
- add missing `filter` argument to `LHCODataset.load_data`

## Testing
- `python -m py_compile data_model/dataset_bio.py`

------
https://chatgpt.com/codex/tasks/task_e_684d2a5755c08326badc3c2ce5c55c85